### PR TITLE
Revert toastQueue element type to `String`

### DIFF
--- a/Sources/Tardiness/DisplayToastAction+Environment.swift
+++ b/Sources/Tardiness/DisplayToastAction+Environment.swift
@@ -43,8 +43,8 @@ public struct DisplayToastAction: Sendable {
 
     @_disfavoredOverload
     @MainActor
-    public func callAsFunction(_ toast: String) {
-        callAsFunction(verbatim: toast)
+    public func callAsFunction<S: StringProtocol>(_ toast: S) {
+        callAsFunction(verbatim: .init(toast))
     }
 }
 

--- a/Sources/Tardiness/DisplayToastAction+Environment.swift
+++ b/Sources/Tardiness/DisplayToastAction+Environment.swift
@@ -16,9 +16,9 @@ public struct DisplayToastAction: Sendable {
     }
 
     @MainActor
-    public func callAsFunction(_ toast: String.LocalizationValue) {
+    public func callAsFunction(verbatim toast: String) {
         if let handler {
-            handler.queueMessage(toast)
+            handler.queueMessage(verbatim: toast)
         } else {
             let errorMessage = """
                 Calling DisplayToastAction with no ToastHandler. This means you forgot to set the environment.
@@ -29,6 +29,11 @@ public struct DisplayToastAction: Sendable {
         }
     }
 
+    @MainActor
+    public func callAsFunction(_ toast: String.LocalizationValue) {
+        callAsFunction(verbatim: .init(localized: toast))
+    }
+
     @_disfavoredOverload
     @available(*, deprecated, message: "Use `callAsFunction(_:)` with `String.LocalizationValue` instead.")
     @MainActor
@@ -37,10 +42,9 @@ public struct DisplayToastAction: Sendable {
     }
 
     @_disfavoredOverload
-    @available(*, deprecated, message: "Use `callAsFunction(_:)` with `String.LocalizationValue` instead.")
     @MainActor
     public func callAsFunction(_ toast: String) {
-        callAsFunction(.init(toast))
+        callAsFunction(verbatim: toast)
     }
 }
 

--- a/Sources/Tardiness/ToastHandler+Environment.swift
+++ b/Sources/Tardiness/ToastHandler+Environment.swift
@@ -10,10 +10,10 @@ import Observation
 @Observable
 public final class ToastHandler: Sendable {
     @MainActor
-    public private(set) var currentToastMessage: String.LocalizationValue?
+    public private(set) var currentToastMessage: String?
 
     @MainActor
-    @ObservationIgnored private var toastQueue: [String.LocalizationValue] = []
+    @ObservationIgnored private var toastQueue: [String] = []
     @MainActor
     @ObservationIgnored private var currentToastShowingTask: Task<Void, Never>?
 

--- a/Sources/Tardiness/ToastHandler+Environment.swift
+++ b/Sources/Tardiness/ToastHandler+Environment.swift
@@ -28,9 +28,14 @@ public final class ToastHandler: Sendable {
     public init() {}
 
     @MainActor
-    public func queueMessage(_ message: String.LocalizationValue) {
+    public func queueMessage(verbatim message: String) {
         toastQueue.append(message)
         displayNextToastIfAvailable()
+    }
+
+    @MainActor
+    public func queueMessage(_ message: String.LocalizationValue) {
+        queueMessage(verbatim: .init(localized: message))
     }
 
     @_disfavoredOverload
@@ -41,10 +46,9 @@ public final class ToastHandler: Sendable {
     }
 
     @_disfavoredOverload
-    @available(*, deprecated, message: "Use `queueMessage(_:)` with `String.LocalizationValue` instead.")
     @MainActor
     public func queueMessage(_ message: String) {
-        queueMessage(.init(message))
+        queueMessage(verbatim: message)
     }
 
     @MainActor

--- a/Sources/Tardiness/ToastHandler+Environment.swift
+++ b/Sources/Tardiness/ToastHandler+Environment.swift
@@ -47,8 +47,8 @@ public final class ToastHandler: Sendable {
 
     @_disfavoredOverload
     @MainActor
-    public func queueMessage(_ message: String) {
-        queueMessage(verbatim: message)
+    public func queueMessage<S: StringProtocol>(_ message: S) {
+        queueMessage(verbatim: .init(message))
     }
 
     @MainActor

--- a/Sources/Tardiness/ToastView.swift
+++ b/Sources/Tardiness/ToastView.swift
@@ -17,7 +17,7 @@ struct ToastView: View {
     public var body: some View {
         Group {
             if let toastMessage = toastHandler.currentToastMessage {
-                Text(String(localized: toastMessage))
+                Text(toastMessage)
                     .font(.caption)
                     .foregroundStyle(Color.white)
                     .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
Since `String` is much more widely used in products, and easier to handle both `String.LocalizationValue` and `String` for users.

Instead, Tardiness now accepts both `String` and `String.LocalizationValue` in calls.