### PR TITLE
Migrate to Swift 6.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Tardiness
-    
+
+![Swift 6.1+](https://img.shields.io/badge/swift-6.1%2B-F05138.svg)
+![SPM Compatible](https://img.shields.io/badge/spm-compatible-F05138.svg)
+![Platforms](https://img.shields.io/badge/platform-ios%20%7C%20macos%20%7C%20watchos%20%7C%20tvos-lightgray)
+![License](https://img.shields.io/badge/License-MIT-blue.svg)
+
 An easy-to-use toast displayer & handler made specifically for SwiftUI
 
 ## Why Tardiness

--- a/Sources/Tardiness/ToastDisplayModifier.swift
+++ b/Sources/Tardiness/ToastDisplayModifier.swift
@@ -25,7 +25,7 @@ public extension View {
     func displayToast<Toast: View>(
         on alignment: Alignment,
         handledBy toastHandler: ToastHandler,
-        toastMaker: @escaping (ToastHandler) -> Toast
+        toastMaker: @escaping (ToastHandler) -> Toast,
     ) -> some View {
         self.modifier(
             ToastDisplayModifier(


### PR DESCRIPTION
This pull request updates the project to require Swift 6.1, adds several informative badges to the `README.md`, and makes a minor formatting adjustment to the `displayToast` function signature. The most significant changes are grouped below:

**Project requirements and documentation:**

* Updated the Swift tools version in `Package.swift` from 6.0 to 6.1, ensuring the package requires at least Swift 6.1 to build.
* Added badges to the top of the `README.md` to indicate Swift version support, SPM compatibility, supported platforms, and license.

**API formatting:**

* Added a trailing comma to the `toastMaker` parameter in the `displayToast` function signature in `ToastDisplayModifier.swift` for improved formatting and consistency.